### PR TITLE
Treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(Tooling)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUDEV REQUIRED libudev)
@@ -27,6 +26,8 @@ add_library(customkbd_core
     src/customkbd/InputDaemon.cpp
     src/customkbd/Logger.cpp
 )
+
+target_compile_options(customkbd_core PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Werror)
 
 target_include_directories(customkbd_core
     PUBLIC
@@ -52,6 +53,7 @@ add_executable(customkbd src/cli/main.cpp)
 foreach(tgt IN ITEMS customkbd-daemon customkbd)
     target_link_libraries(${tgt} PRIVATE customkbd_core)
     target_include_directories(${tgt} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_compile_options(${tgt} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Werror)
 endforeach()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")

--- a/cmake/Tooling.cmake
+++ b/cmake/Tooling.cmake
@@ -1,3 +1,0 @@
-if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wall -Wextra -Wpedantic -Wconversion)
-endif()

--- a/src/customkbd/InputDaemon.cpp
+++ b/src/customkbd/InputDaemon.cpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <chrono>
 
-static const std::map<std::string, int> keymap = {
+static const std::map<std::string, unsigned short> keymap = {
     // letters
     {"a", KEY_A},
     {"b", KEY_B},
@@ -99,7 +99,7 @@ static const std::map<std::string, int> keymap = {
     // escape
     {"esc", KEY_ESC}};
 
-static const std::map<int, std::string> code_to_name_map = {
+static const std::map<unsigned short, std::string> code_to_name_map = {
     // letters
     {KEY_A, "a"},
     {KEY_B, "b"},
@@ -342,8 +342,6 @@ void InputDaemon::forwardEvent(const struct input_event &ev)
 
 void InputDaemon::emitMapped(const std::vector<std::string> &actions)
 {
-    bool ctrl_pressed = false;
-
     for (const auto &a : actions)
     {
         if (a.rfind("type:", 0) == 0)
@@ -361,7 +359,7 @@ void InputDaemon::emitMapped(const std::vector<std::string> &actions)
                 }
                 else
                 {
-                    keyname = std::string(1, std::tolower(ch));
+                    keyname = std::string(1, static_cast<unsigned char>(std::tolower(ch)));
                 }
 
                 auto it = keymap.find(keyname);
@@ -371,7 +369,7 @@ void InputDaemon::emitMapped(const std::vector<std::string> &actions)
                     continue;
                 }
 
-                int code = it->second;
+                unsigned short code = it->second;
 
                 struct input_event ev{};
                 ev.type = EV_KEY;


### PR DESCRIPTION
 - Resolve the conversion warnings in InputDaemon.cpp
 - Add the compile flags to build targets