### PR TITLE
Use blocking read to wait for key events

### DIFF
--- a/src/customkbd/InputDaemon.cpp
+++ b/src/customkbd/InputDaemon.cpp
@@ -208,7 +208,7 @@ InputDaemon::~InputDaemon()
 
 bool InputDaemon::init()
 {
-    fd = open(devicePath.c_str(), O_RDONLY | O_NONBLOCK);
+    fd = open(devicePath.c_str(), O_RDONLY);
     if (fd < 0)
     {
         std::cerr << "[ERROR] Failed to open device: " << devicePath << std::endl;


### PR DESCRIPTION
Switches the input device to blocking mode so the daemon no longer spins in a busy loop. This allows it to idle without consuming CPU when no keyboard events are available.